### PR TITLE
Use the text prop to set text in editor

### DIFF
--- a/src/DragTextEditor.js
+++ b/src/DragTextEditor.js
@@ -51,7 +51,7 @@ export default class DragTextEditor extends Component {
       h: h < minHeight ? minHeight :h,
       ended:true,
       giveInput:false,
-      text: this.props.PlaceHolder==null?TEXT:this.props.PlaceHolder,
+      text: this.props.text==null?TEXT:this.props.PlaceHolder,
       isBorder:false,
     };
     


### PR DESCRIPTION
The documentation says that the `text` prop is used to set the contents of the editor, but the current code expects to find that information in a `PlaceHolder` prop.  This PR fixes the code to match the documentation.